### PR TITLE
Fixed limitation to 99 sequential plots in plotpriv.tcl

### DIFF
--- a/modules/plotchart/plotpriv.tcl
+++ b/modules/plotchart/plotpriv.tcl
@@ -245,7 +245,7 @@ proc ::Plotchart::MarginsRectangle { w argv {notext 2.0} {text_width 8}} {
     variable scaling
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }
@@ -389,7 +389,7 @@ proc ::Plotchart::MarginsSquare { w {notext 2.0} {text_width 8}} {
     variable scaling
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }
@@ -450,7 +450,7 @@ proc ::Plotchart::MarginsCircle { w args } {
    variable scaling
 
    if { [string match {[0-9]*} $w] } {
-       set c [string range $w 2 end]
+       set c .[join [lrange [split $w .] 1 end] .]
    } else {
        set c $w
    }
@@ -567,7 +567,7 @@ proc ::Plotchart::Margins3DPlot { w } {
     variable scaling
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }
@@ -850,7 +850,7 @@ proc ::Plotchart::DrawMask { w } {
     }
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }
@@ -941,7 +941,7 @@ proc ::Plotchart::DrawTernaryMask { w } {
     }
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }
@@ -986,7 +986,7 @@ proc ::Plotchart::DrawTitle { w title {position center}} {
     variable config
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }
@@ -1044,7 +1044,7 @@ proc ::Plotchart::DrawSubtitle { w title } {
     variable config
 
     if { [string match {[0-9]*} $w] } {
-        set c [string range $w 2 end]
+        set c .[join [lrange [split $w .] 1 end] .]
     } else {
         set c $w
     }


### PR DESCRIPTION
Fixed issue described by this error messages:

invalid command name "0.csvplot1.f.main.p1"
*** ERROR INFO ***
invalid command name "0.csvplot1.f.main.p1"
    while executing
"$c cget -borderwidth"
    (procedure "MarginsRectangle" line 40)
    invoked from within
"MarginsRectangle $w $args"
    (procedure "::Plotchart::createBarchart" line 21)
    invoked from within
"::Plotchart::createBarchart $canvas $xlabels $ylim $layout {*}$args"

INNER:invokeStk1 0.csvplot1.f.main.p1 cget -borderwidth

CALL:MarginsRectangle 100.csvplot1.f.main.p1 {}
CALL:::Plotchart::createBarchart .csvplot1.f.main.p1 {Mean Maximum Minimum} {0 0.010000000000000002 0.0010000000000000002} 1